### PR TITLE
[feat] MonthView 캐러셀 구현

### DIFF
--- a/lib/presentation/widgets/schedule/month_page.dart
+++ b/lib/presentation/widgets/schedule/month_page.dart
@@ -1,10 +1,14 @@
+import 'package:calendar/presentation/providers/schedules_provider.dart';
+import 'package:calendar/presentation/widgets/common/custom_carousel.dart';
 import 'package:calendar/presentation/widgets/layout/custom_app_bar.dart';
 import 'package:calendar/presentation/widgets/layout/custom_navigation_bar.dart';
 import 'package:calendar/presentation/widgets/schedule/month_selector.dart';
 import 'package:calendar/presentation/widgets/schedule/month_view.dart';
 import 'package:calendar/presentation/widgets/schedule/schedule_sheet.dart';
+import 'package:carousel_slider/carousel_options.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 
 class MonthPage extends StatelessWidget {
   static const routeName = 'schedule/month';
@@ -16,9 +20,7 @@ class MonthPage extends StatelessWidget {
     return Scaffold(
         body: Stack(children: [
           Column(children: [
-            CustomAppBar(
-                isScheduleAppBar: true,
-                rightActions: [
+            CustomAppBar(isScheduleAppBar: true, rightActions: [
               CustomAppBarModeButton(
                   type: CustomAppBarModeType.vertical,
                   onPressed: () {
@@ -27,7 +29,7 @@ class MonthPage extends StatelessWidget {
               const CustomAppBarSearchButton(type: PageType.schedule),
             ]),
             const MonthSelector(),
-            const MonthView()
+            const _MonthViewCarousel()
           ]),
           const ScheduleSheet(minSizeRatio: 0.275)
         ]),
@@ -35,6 +37,31 @@ class MonthPage extends StatelessWidget {
             selectedType: CustomNavigationType.schedule,
             onPressSchedule: () {
               context.pushNamed('weekPage');
+            }));
+  }
+}
+
+class _MonthViewCarousel extends StatelessWidget {
+  const _MonthViewCarousel();
+
+  @override
+  Widget build(BuildContext context) {
+    final schedulesProvider = context.watch<SchedulesProvider>();
+
+    return Expanded(
+        child: CustomCarousel<DateTime>(
+            options: CarouselOptions(
+                height: double.infinity,
+                enableInfiniteScroll: false,
+                autoPlay: false,
+                viewportFraction: 1),
+            items: schedulesProvider.neighborMonthDates,
+            selectedIndex: schedulesProvider.selectedNeighborMonthDateIndex,
+            onPageChanged: (index) {
+              schedulesProvider.selectNeighborMonthDate(index);
+            },
+            renderItem: (item, isActive, index, controller) {
+              return MonthView(monthDate: item);
             }));
   }
 }

--- a/lib/presentation/widgets/schedule/month_selector.dart
+++ b/lib/presentation/widgets/schedule/month_selector.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'package:calendar/presentation/providers/schedules_provider.dart';
 import 'package:calendar/presentation/widgets/common/custom_carousel.dart';
 import 'package:calendar/presentation/widgets/common/custom_theme.dart';
@@ -12,17 +10,8 @@ class MonthSelector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final selectedMonthDate =
-        context.watch<SchedulesProvider>().getSelectedMonthDate();
-    final Queue<DateTime> initialItems = Queue();
-
-    const dMonthMin = -5;
-    const dMonthMax = 5;
-
-    for (var dMonth = dMonthMin; dMonth <= dMonthMax; dMonth++) {
-      initialItems.addLast(
-          DateTime(selectedMonthDate.year, selectedMonthDate.month + dMonth));
-    }
+    final schedulesProvider = context.watch<SchedulesProvider>();
+    final selectedMonthDate = schedulesProvider.getSelectedMonthDate();
 
     return CustomCarousel<DateTime>(
         options: CarouselOptions(
@@ -31,12 +20,10 @@ class MonthSelector extends StatelessWidget {
           enableInfiniteScroll: false,
           autoPlay: false,
         ),
-        initialItems: initialItems,
-        initialSelectedIndex: -dMonthMin,
-        createPrevItem: (item) => DateTime(item.year, item.month - 1),
-        createNextItem: (item) => DateTime(item.year, item.month + 1),
-        onSelectItem: (item) {
-          context.read<SchedulesProvider>().setSelectedMonthDate(item);
+        items: schedulesProvider.neighborMonthDates,
+        selectedIndex: schedulesProvider.selectedNeighborMonthDateIndex,
+        onPageChanged: (index) {
+          schedulesProvider.selectNeighborMonthDate(index);
         },
         renderItem: (item, isActive, index, controller) {
           final text = '${item.year}.${'${item.month}'.padLeft(2, '0')}';
@@ -63,7 +50,7 @@ class MonthSelector extends StatelessWidget {
           } else {
             return TextButton(
                 onPressed: () {
-                  controller.animateToPage(index);
+                  schedulesProvider.selectNeighborMonthDate(index);
                 },
                 style: ButtonStyle(
                   overlayColor: MaterialStateProperty.all(Colors.transparent),

--- a/lib/presentation/widgets/schedule/month_view.dart
+++ b/lib/presentation/widgets/schedule/month_view.dart
@@ -9,126 +9,18 @@ import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
 class MonthView extends StatelessWidget {
-  static const _dayNames = ['일', '월', '화', '수', '목', '금', '토'];
+  final DateTime monthDate;
 
-  const MonthView({super.key});
+  const MonthView({super.key, required this.monthDate});
 
   /// 날짜를 key로 하는 Map을 만들 때 사용.
   String _getDayKey(DateTime dayDate) {
     return '${dayDate.year}:${dayDate.month}:${dayDate.day}';
   }
 
-  Color _getCellColor(int weekDay) {
-    if (weekDay == DateTime.sunday) {
-      return CustomTheme.tint.red;
-    } else if (weekDay == DateTime.saturday) {
-      return CustomTheme.tint.blue;
-    } else {
-      return CustomTheme.scale.max;
-    }
-  }
-
-  Widget _createNameCell(String name, int weekDay) {
-    return Expanded(
-        child: Container(
-            alignment: Alignment.center,
-            height: 28,
-            child: Text(name,
-                style: TextStyle(
-                    fontSize: 17,
-                    fontWeight: FontWeight.w400,
-                    color: _getCellColor(weekDay)))));
-  }
-
-  Widget _createNameRow() {
-    return Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: _dayNames
-            .mapIndexed(
-                (index, name) => _createNameCell(name, index == 0 ? 7 : index))
-            .toList());
-  }
-
-  Widget _createDayLabel(BuildContext context, DateTime dayDate) {
-    final selectedMonthDate =
-        context.watch<SchedulesProvider>().getSelectedMonthDate();
-
-    final now = CustomDateUtils.getNow();
-
-    final decoration = !CustomDateUtils.areSameDays(now, dayDate)
-        ? null
-        : BoxDecoration(
-            color: CustomTheme.background.secondary,
-            borderRadius: BorderRadius.circular(8));
-
-    final color = dayDate.month != selectedMonthDate.month
-        ? CustomTheme.scale.scale3
-        : _getCellColor(dayDate.weekday);
-
-    return Container(
-        width: double.infinity,
-        height: 26,
-        alignment: Alignment.center,
-        decoration: decoration,
-        child: Text('${dayDate.day}',
-            style: TextStyle(
-                fontSize: 17, fontWeight: FontWeight.w400, color: color)));
-  }
-
-  Widget _createAllDayMarker(ScheduleModel schedule) {
-    return Container(
-        width: double.infinity,
-        height: 6,
-        margin: const EdgeInsets.only(top: 2),
-        decoration: BoxDecoration(
-            color: markerColors[schedule.colorIndex % markerColors.length]));
-  }
-
-  Widget _createHoursMarker(ScheduleModel schedule) {
-    return Container(
-        width: 6,
-        height: 6,
-        decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            color: markerColors[schedule.colorIndex % markerColors.length]));
-  }
-
-  Widget _createDayCell(BuildContext context, DateTime dayDate,
-      List<_ScheduleInfo> scheduleInfos) {
-    final allDayMarkers = scheduleInfos
-        .where((info) => info.schedule.type == ScheduleType.allDay)
-        .map((info) => _createAllDayMarker(info.schedule));
-
-    final hoursMarkers = scheduleInfos
-        .where((info) => info.schedule.type == ScheduleType.hours)
-        .map((info) => _createHoursMarker(info.schedule))
-        .toList();
-
-    return Expanded(
-        child: GestureDetector(
-      onTap: () {
-        final schedulesProvider = context.read<SchedulesProvider>();
-        schedulesProvider.getOneDaySchedules(dayDate);
-        context.pushNamed('dayPage',
-            params: {'selectedDate': CustomDateUtils.dateToString(dayDate)});
-      },
-      child: Container(
-          constraints: const BoxConstraints(minHeight: 58),
-          child: Column(children: [
-            _createDayLabel(context, dayDate),
-            ...allDayMarkers,
-            Container(
-                margin: const EdgeInsets.only(top: 2),
-                child: Wrap(spacing: 2, children: hoursMarkers))
-          ])),
-    ));
-  }
-
-  List<Widget> _createDayRows(BuildContext context) {
+  @override
+  Widget build(BuildContext context) {
     final schedules = context.watch<SchedulesProvider>().selectedMonthSchedules;
-
-    final selectedMonthDate =
-        context.watch<SchedulesProvider>().getSelectedMonthDate();
 
     // key: 각 날짜.
     // value: 해당 날짜에 있는 스케줄들.
@@ -159,21 +51,168 @@ class MonthView extends StatelessWidget {
           (info1, info2) => info2.dayDates.length - info1.dayDates.length);
     });
 
-    return CustomDateUtils.getMonthCalendar(selectedMonthDate)
-        .map((week) => Row(
-            children: week
-                .map((dayDate) => _createDayCell(
-                    context, dayDate, scheduleMap[_getDayKey(dayDate)] ?? []))
-                .toList()))
-        .toList();
+    return Container(
+        margin: const EdgeInsets.only(top: 28),
+        child: Column(children: [
+          const _NameRow(),
+          ...CustomDateUtils.getMonthCalendar(monthDate).map((week) => Row(
+              children: week
+                  .map((dayDate) => _DayCell(
+                      dayDate: dayDate,
+                      scheduleInfos: scheduleMap[_getDayKey(dayDate)] ?? []))
+                  .toList()))
+        ]));
   }
+}
+
+class _NameRow extends StatelessWidget {
+  static const _dayNames = ['일', '월', '화', '수', '목', '금', '토'];
+
+  const _NameRow();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: _dayNames
+            .mapIndexed((index, name) =>
+                _NameCell(name: name, weekDay: index == 0 ? 7 : index))
+            .toList());
+  }
+}
+
+class _NameCell extends StatelessWidget {
+  final String name;
+  final int weekDay;
+
+  const _NameCell({required this.name, required this.weekDay});
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+        child: Container(
+            alignment: Alignment.center,
+            height: 28,
+            child: Text(name,
+                style: TextStyle(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w400,
+                    color: _getCellColor(weekDay)))));
+  }
+}
+
+class _DayCell extends StatelessWidget {
+  final DateTime dayDate;
+  final List<_ScheduleInfo> scheduleInfos;
+
+  const _DayCell({required this.dayDate, required this.scheduleInfos});
+
+  @override
+  Widget build(BuildContext context) {
+    final schedulesProvider = context.watch<SchedulesProvider>();
+
+    final allDayMarkers = scheduleInfos
+        .where((info) => info.schedule.type == ScheduleType.allDay)
+        .map((info) => _AllDayMarker(schedule: info.schedule));
+
+    final hoursMarkers = scheduleInfos
+        .where((info) => info.schedule.type == ScheduleType.hours)
+        .map((info) => _HoursMarker(schedule: info.schedule))
+        .toList();
+
+    return Expanded(
+        child: GestureDetector(
+      onTap: () {
+        schedulesProvider.getOneDaySchedules(dayDate);
+
+        context.pushNamed('dayPage',
+            params: {'selectedDate': CustomDateUtils.dateToString(dayDate)});
+      },
+      child: Container(
+          constraints: const BoxConstraints(minHeight: 58),
+          child: Column(children: [
+            _DayLabel(dayDate: dayDate),
+            ...allDayMarkers,
+            Container(
+                margin: const EdgeInsets.only(top: 2),
+                child: Wrap(spacing: 2, children: hoursMarkers))
+          ])),
+    ));
+  }
+}
+
+class _DayLabel extends StatelessWidget {
+  final DateTime dayDate;
+
+  const _DayLabel({required this.dayDate});
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedMonthDate =
+        context.watch<SchedulesProvider>().getSelectedMonthDate();
+
+    final now = CustomDateUtils.getNow();
+
+    final decoration = !CustomDateUtils.areSameDays(now, dayDate)
+        ? null
+        : BoxDecoration(
+            color: CustomTheme.background.secondary,
+            borderRadius: BorderRadius.circular(8));
+
+    final color = dayDate.month != selectedMonthDate.month
+        ? CustomTheme.scale.scale3
+        : _getCellColor(dayDate.weekday);
+
+    return Container(
+        width: double.infinity,
+        height: 26,
+        alignment: Alignment.center,
+        decoration: decoration,
+        child: Text('${dayDate.day}',
+            style: TextStyle(
+                fontSize: 17, fontWeight: FontWeight.w400, color: color)));
+  }
+}
+
+Color _getCellColor(int weekDay) {
+  if (weekDay == DateTime.sunday) {
+    return CustomTheme.tint.red;
+  } else if (weekDay == DateTime.saturday) {
+    return CustomTheme.tint.blue;
+  } else {
+    return CustomTheme.scale.max;
+  }
+}
+
+class _AllDayMarker extends StatelessWidget {
+  final ScheduleModel schedule;
+
+  const _AllDayMarker({required this.schedule});
 
   @override
   Widget build(BuildContext context) {
     return Container(
-        margin: const EdgeInsets.only(top: 28),
-        child:
-            Column(children: [_createNameRow(), ..._createDayRows(context)]));
+        width: double.infinity,
+        height: 6,
+        margin: const EdgeInsets.only(top: 2),
+        decoration: BoxDecoration(
+            color: markerColors[schedule.colorIndex % markerColors.length]));
+  }
+}
+
+class _HoursMarker extends StatelessWidget {
+  final ScheduleModel schedule;
+
+  const _HoursMarker({required this.schedule});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+        width: 6,
+        height: 6,
+        decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: markerColors[schedule.colorIndex % markerColors.length]));
   }
 }
 


### PR DESCRIPTION
* 사전작업
  * MonthView 및 MonthSelector 동기화를 위하여 상태 관리를 위로 (ScheduleProvider 단까지) 올림
  * MonthView 구조 수정 편하게 widget들로 쪼개서 리팩토링
* MonthView에 Carousel 씌움
* MonthView 및 MonthSelector 스와이프 <-> ScheduleProvider 연동